### PR TITLE
HigoCore 0.1.0 - Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "HigoCore",
-            url: "https://github.com/HGSNS/HigoCore/releases/download/0.0.2/HigoCore.xcframework.zip",
-            checksum: "a942292d14f35e25b562c58b7a2630b3c8bf5539528e67ebc184d57ea1fa9024"
+            url: "https://github.com/HGSNS/HigoCore/releases/download/0.1.0/HigoCore.xcframework.zip",
+            checksum: "67f84b1a035cc676d07c99e56a3378f2f15f68389a767fb6d0c117b2caabb9e8"
         )
     ]
 )


### PR DESCRIPTION
This PR updates the binary target URL and checksum for 0.1.0.

URL: https://github.com/HGSNS/HigoCore/releases/download/0.1.0/HigoCore.xcframework.zip
Checksum: `67f84b1a035cc676d07c99e56a3378f2f15f68389a767fb6d0c117b2caabb9e8`