### PR TITLE
HigoCore 0.1.13 - Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "HigoCore",
-            url: "https://github.com/HGSNS/HigoCore/releases/download/0.1.12/HigoCore.xcframework.zip",
-            checksum: "921c791dc52ebb363f2391897de94ebe2c64bce34208068bf4f92d7de212f94c"
+            url: "https://github.com/HGSNS/HigoCore/releases/download/0.1.13/HigoCore.xcframework.zip",
+            checksum: "7f076b14bc8854ffc79055535e0eab7b7e078f32f7b71fd854c33329cafb33cf"
         )
     ]
 )


### PR DESCRIPTION
This PR updates the binary target URL and checksum for 0.1.13.

URL: https://github.com/HGSNS/HigoCore/releases/download/0.1.13/HigoCore.xcframework.zip
Checksum: `7f076b14bc8854ffc79055535e0eab7b7e078f32f7b71fd854c33329cafb33cf`