### PR TITLE
HigoCore 0.1.16 - Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "HigoCore",
-            url: "https://github.com/HGSNS/HigoCore/releases/download/0.1.15/HigoCore.xcframework.zip",
-            checksum: "9bdf66a375836182faf64e8161e40cf17d379e9ccc017f54425a1037c812946e"
+            url: "https://github.com/HGSNS/HigoCore/releases/download/0.1.16/HigoCore.xcframework.zip",
+            checksum: "13b857ef43193adbd75f1e584ed643c3d1b1a997203ec376e6c0ff01432be72b"
         )
     ]
 )


### PR DESCRIPTION
This PR updates the binary target URL and checksum for 0.1.16.

URL: https://github.com/HGSNS/HigoCore/releases/download/0.1.16/HigoCore.xcframework.zip
Checksum: `13b857ef43193adbd75f1e584ed643c3d1b1a997203ec376e6c0ff01432be72b`